### PR TITLE
Change Attendance to avoid redundant date to string conversions [ZG-826]

### DIFF
--- a/FortnoxAPILibrary.Tests/Connectors/AttendanceTransactionConnectorTests.cs
+++ b/FortnoxAPILibrary.Tests/Connectors/AttendanceTransactionConnectorTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
 using FortnoxAPILibrary.Connectors;
 using FortnoxAPILibrary.Entities;
@@ -109,8 +108,7 @@ namespace FortnoxAPILibrary.Tests.Connectors
         public void GetShouldReturnResult()
         {
             var attendanceTransaction = GetNewOrExistingAttendanceTransaction();
-            DateTime.TryParseExact(attendanceTransaction.Date, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date);
-            var result = _connector.Get(attendanceTransaction.EmployeeId, date, attendanceTransaction.CauseCode);
+            var result = _connector.Get(attendanceTransaction.EmployeeId, attendanceTransaction.Date, attendanceTransaction.CauseCode);
 
             CheckForError(_connector);
 

--- a/FortnoxAPILibrary/Connectors/AttendanceTransactionConnector.cs
+++ b/FortnoxAPILibrary/Connectors/AttendanceTransactionConnector.cs
@@ -16,7 +16,7 @@ namespace FortnoxAPILibrary.Connectors
         /// Find an attendanceTransaction based on attendanceTransactionId
         /// </summary>
         /// <returns>The found attendanceTransaction</returns>
-        AttendanceTransaction Get(string employeeId, DateTime? date, AttendanceCauseCode? code);
+        AttendanceTransaction Get(string employeeId, string date, AttendanceCauseCode code);
 
         /// <summary>
         /// Updates an attendanceTransaction
@@ -36,7 +36,7 @@ namespace FortnoxAPILibrary.Connectors
         /// Gets a list of attendanceTransactions
         /// </summary>
         /// <returns>A list of attendanceTransactions</returns>
-        AttendanceTransactions Find(string employeeId = null, DateTime? date = null);
+        AttendanceTransactions Find(string employeeId = null, string date = null);
     }
 
     /// <summary>
@@ -56,9 +56,9 @@ namespace FortnoxAPILibrary.Connectors
         public Filter.AttendanceTransaction FilterBy { get; set; }
 
         /// <inheritdoc />
-        public AttendanceTransaction Get(string employeeId, DateTime? date, AttendanceCauseCode? code)
+        public AttendanceTransaction Get(string employeeId, string date, AttendanceCauseCode code)
         {
-            return BaseGet(employeeId, date?.ToString(APIConstants.DateFormat), code?.GetStringValue());
+            return BaseGet(employeeId, date, code.GetStringValue());
         }
 
         /// <inheritdoc />
@@ -68,10 +68,8 @@ namespace FortnoxAPILibrary.Connectors
                 throw new ArgumentException("AttendanceTransaction must have an EmployeeId to be able to update", nameof(attendanceTransaction.EmployeeId));
             if (string.IsNullOrEmpty(attendanceTransaction.Date))
                 throw new ArgumentException("AttendanceTransaction must have an Date to be able to update", nameof(attendanceTransaction.Date));
-            if (!attendanceTransaction.CauseCode.HasValue)
-                throw new ArgumentException("AttendanceTransaction must have an CauseCode to be able to update", nameof(attendanceTransaction.CauseCode));
 
-            var code = attendanceTransaction.CauseCode?.GetStringValue();
+            var code = attendanceTransaction.CauseCode.GetStringValue();
             return BaseUpdate(attendanceTransaction, attendanceTransaction.EmployeeId, attendanceTransaction.Date, code);
         }
 
@@ -82,7 +80,7 @@ namespace FortnoxAPILibrary.Connectors
         }
 
         /// <inheritdoc />
-        public AttendanceTransactions Find(string employeeId = null, DateTime? date = null)
+        public AttendanceTransactions Find(string employeeId = null, string date = null)
         {
             Parameters = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(employeeId))
@@ -90,9 +88,9 @@ namespace FortnoxAPILibrary.Connectors
                 Parameters.Add("employeeid", employeeId);
             }
 
-            if (date.HasValue)
+            if (!string.IsNullOrEmpty(date))
             {
-                Parameters.Add("date", date.Value.ToString(APIConstants.DateFormat));
+                Parameters.Add("date", date);
             }
 
             return BaseFind();

--- a/FortnoxAPILibrary/Entities/AttendanceTransaction.cs
+++ b/FortnoxAPILibrary/Entities/AttendanceTransaction.cs
@@ -14,7 +14,7 @@ namespace FortnoxAPILibrary.Entities
 
         ///<summary> Cause code </summary>
         [XmlElement(ElementName = "CauseCode")]
-        public AttendanceCauseCode? CauseCode { get; set; }
+        public AttendanceCauseCode CauseCode { get; set; }
 
         ///<summary> Date </summary>
         [XmlElement(ElementName = "Date")]


### PR DESCRIPTION
CauseCode is required for AttendanceTransaction, no sense to have it nullable.